### PR TITLE
Use getIDToken instead of forcing refresh

### DIFF
--- a/TraceCovid19/Sources/Models/AppStatus.swift
+++ b/TraceCovid19/Sources/Models/AppStatus.swift
@@ -19,6 +19,6 @@ struct AppStatusDetail: Decodable {
 
 extension AppStatusDetail {
     var minAppVersion: AppVersion? {
-        return AppVersion(versionString: minVersion)
+        AppVersion(versionString: minVersion)
     }
 }

--- a/TraceCovid19/Sources/Models/AppVersion.swift
+++ b/TraceCovid19/Sources/Models/AppVersion.swift
@@ -52,7 +52,7 @@ extension AppVersion {
     }
 
     var versionString: String {
-        return "\(major)\(separator)\(minor)\(separator)\(patch)"
+        "\(major)\(separator)\(minor)\(separator)\(patch)"
     }
 }
 

--- a/TraceCovid19/Sources/Models/CoreData/DeepContactUserEntity.swift
+++ b/TraceCovid19/Sources/Models/CoreData/DeepContactUserEntity.swift
@@ -27,6 +27,6 @@ extension DeepContactUserEntity {
     }
 
     func toDeepContactUser() -> DeepContactUser {
-         return DeepContactUser(tempId: tempId, startTime: startTime, endTime: endTime)
+         DeepContactUser(tempId: tempId, startTime: startTime, endTime: endTime)
      }
 }

--- a/TraceCovid19/Sources/Models/CoreData/TempUserIdEntity.swift
+++ b/TraceCovid19/Sources/Models/CoreData/TempUserIdEntity.swift
@@ -24,6 +24,6 @@ extension TempUserIdEntity {
     }
 
     func toTempUserId() -> TempUserId {
-        return TempUserId(tempId: tempId, startTime: startTime, endTime: expiryTime)
+        TempUserId(tempId: tempId, startTime: startTime, endTime: expiryTime)
     }
 }

--- a/TraceCovid19/Sources/Models/CoreData/TraceDataEntity.swift
+++ b/TraceCovid19/Sources/Models/CoreData/TraceDataEntity.swift
@@ -26,13 +26,13 @@ extension TraceDataEntity {
     }
 
     func toTraceDataRecord() -> TraceDataRecord {
-        return TraceDataRecord(timestamp: timestamp, tempId: tempId, rssi: rssi?.doubleValue, txPower: txPower?.doubleValue)
+        TraceDataRecord(timestamp: timestamp, tempId: tempId, rssi: rssi?.doubleValue, txPower: txPower?.doubleValue)
     }
 }
 
 extension TraceDataEntity {
     var isValidConnection: Bool {
-        return timestamp != nil
+        timestamp != nil
             && tempId != nil
             && tempId!.isValidTempId
             && rssi != nil
@@ -41,7 +41,7 @@ extension TraceDataEntity {
 
 extension String {
     var isValidTempId: Bool {
-        return self != CoreDataService.Event.scanningStarted.rawValue
+        self != CoreDataService.Event.scanningStarted.rawValue
             && self != CoreDataService.Event.scanningStopped.rawValue
             && self != CoreDataService.Event.scanningRestarted.rawValue
             && self != BluetraceConfig.initialMsg

--- a/TraceCovid19/Sources/Models/PrefectureModel.swift
+++ b/TraceCovid19/Sources/Models/PrefectureModel.swift
@@ -66,11 +66,11 @@ enum PrefectureModel: String, CaseIterable {
     }
 
     var index: Int {
-        return rawIndex == errorIndex ? errorIndex : rawIndex + 1 // 0始まりになってしまうので、B/Eに投げる場合などは1を加算（異常系は固定）
+        rawIndex == errorIndex ? errorIndex : rawIndex + 1 // 0始まりになってしまうので、B/Eに投げる場合などは1を加算（異常系は固定）
     }
 
     static var rawValues: [String] {
-        return allCases.compactMap { $0.rawValue }
+        allCases.compactMap { $0.rawValue }
     }
 
     init?(index: Int?) {

--- a/TraceCovid19/Sources/Navigations/NavigationProtocol.swift
+++ b/TraceCovid19/Sources/Navigations/NavigationProtocol.swift
@@ -38,6 +38,6 @@ extension ModalNavigationProtocol {
 
 extension ModalNavigationProtocol where Self: UIViewController {
     var presenter: UIViewController {
-        return self
+        self
     }
 }

--- a/TraceCovid19/Sources/Networks/API/CancelPositiveAPI.swift
+++ b/TraceCovid19/Sources/Networks/API/CancelPositiveAPI.swift
@@ -11,13 +11,13 @@ final class CancelPositiveAPIRequest: APIRequestProtocol {
     typealias Response = EmpytResponse
 
     var method: APIRequestMethod {
-        return .delete
+        .delete
     }
     var path: String {
-        return "/users/me/diagnosis_keys"
+        "/users/me/diagnosis_keys"
     }
     var isNeedAuthentication: Bool {
-        return true
+        true
     }
 
     var encodingType: ParameterEncodingType {
@@ -26,7 +26,7 @@ final class CancelPositiveAPIRequest: APIRequestProtocol {
      }
 
     var parameters: [String: Any] {
-        return (try? randomIDs.asDictionary()) ?? [:]
+        (try? randomIDs.asDictionary()) ?? [:]
     }
 
     private let randomIDs: RandomIDs

--- a/TraceCovid19/Sources/Networks/API/LoginAPI.swift
+++ b/TraceCovid19/Sources/Networks/API/LoginAPI.swift
@@ -11,17 +11,17 @@ final class LoginAPIRequest: APIRequestProtocol {
     typealias Response = LoginAPIResponse
 
     var method: APIRequestMethod {
-        return .post
+        .post
     }
     var path: String {
-        return "/auth/login"
+        "/auth/login"
     }
     var isNeedAuthentication: Bool {
-        return true
+        true
     }
 
     var parameters: [String: Any] {
-        return (try? profile.asDictionary()) ?? [:]
+        (try? profile.asDictionary()) ?? [:]
     }
 
     private let profile: Profile

--- a/TraceCovid19/Sources/Networks/API/ProfileAPI.swift
+++ b/TraceCovid19/Sources/Networks/API/ProfileAPI.swift
@@ -11,13 +11,13 @@ final class ProfilePatchAPIRequest: APIRequestProtocol {
     typealias Response = EmpytResponse
 
     var method: APIRequestMethod {
-        return .patch
+        .patch
     }
     var path: String {
-        return "/users/me/profile"
+        "/users/me/profile"
     }
     var isNeedAuthentication: Bool {
-        return true
+        true
     }
 
     var parameters: [String: Any] {
@@ -42,13 +42,13 @@ final class ProfileDeleteOrganizationCodeAPIRequest: APIRequestProtocol {
     typealias Response = EmpytResponse
 
     var method: APIRequestMethod {
-        return .delete
+        .delete
     }
     var path: String {
-        return "/users/me/organization"
+        "/users/me/organization"
     }
     var isNeedAuthentication: Bool {
-        return true
+        true
     }
 
     var encodingType: ParameterEncodingType {
@@ -57,7 +57,7 @@ final class ProfileDeleteOrganizationCodeAPIRequest: APIRequestProtocol {
     }
 
     var parameters: [String: Any] {
-        return (try? randomIDs.asDictionary()) ?? [:]
+        (try? randomIDs.asDictionary()) ?? [:]
     }
 
     private let randomIDs: RandomIDs

--- a/TraceCovid19/Sources/Networks/API/TraceDataUploadAPI.swift
+++ b/TraceCovid19/Sources/Networks/API/TraceDataUploadAPI.swift
@@ -11,13 +11,13 @@ final class TraceDataUploadAPIRequest: APIRequestProtocol {
     typealias Response = EmpytResponse
 
     var method: APIRequestMethod {
-        return .post
+        .post
     }
     var path: String {
-        return "/users/me/health_center_tokens"
+        "/users/me/health_center_tokens"
     }
     var isNeedAuthentication: Bool {
-        return true
+        true
     }
 
     var parameters: [String: Any] {
@@ -76,6 +76,6 @@ final class TraceDataUploadAPI {
     }
 
     private func creatRandomID() -> String {
-        return UUID().uuidString // TODO: ひとまずランダム値をUUIDv4で生成
+        UUID().uuidString // TODO: ひとまずランダム値をUUIDv4で生成
     }
 }

--- a/TraceCovid19/Sources/Networks/APIClient.swift
+++ b/TraceCovid19/Sources/Networks/APIClient.swift
@@ -67,7 +67,7 @@ final class APIClient {
     }
 
     private func makeDataRequest<T: APIRequestProtocol>(request: T, accessToken: String?) -> DataRequest {
-        return session.request(
+        session.request(
             request.urlString,
             method: Alamofire.HTTPMethod(rawValue: request.method.rawValue),
             parameters: request.parameters,
@@ -79,8 +79,7 @@ final class APIClient {
     private func makeDecodableHandler<T: APIRequestProtocol>(
         request: T,
         completionHandler: @escaping (Result<T.Response, APIRequestError>) -> Void
-    ) -> (DataResponse<T.Response, AFError>) -> Void where T.Response: Decodable {
-        return { result in
+    ) -> (DataResponse<T.Response, AFError>) -> Void where T.Response: Decodable { { result in
             print("[APIClient] \(String(describing: String(data: result.data ?? Data(), encoding: .utf8)))")
 
             guard (result.error?.underlyingError as NSError?)?.code != NSURLErrorNotConnectedToInternet else {
@@ -116,8 +115,7 @@ final class APIClient {
     private func makeEmptyHandler<T: APIRequestProtocol>(
          request: T,
          completionHandler: @escaping (Result<T.Response, APIRequestError>) -> Void
-    ) -> (AFDataResponse<Data?>) -> Void where T.Response == EmpytResponse {
-         return { result in
+    ) -> (AFDataResponse<Data?>) -> Void where T.Response == EmpytResponse { { result in
              print("[APIClient] \(String(describing: String(data: result.data ?? Data(), encoding: .utf8)))")
 
             guard (result.error?.underlyingError as NSError?)?.code != NSURLErrorNotConnectedToInternet else {

--- a/TraceCovid19/Sources/Networks/APIRequest.swift
+++ b/TraceCovid19/Sources/Networks/APIRequest.swift
@@ -70,7 +70,7 @@ protocol APIRequestProtocol: CustomStringConvertible {
 
 extension APIRequestProtocol {
     var scheme: String {
-        return "https://"
+        "https://"
     }
     var host: String {
         #if DEV
@@ -84,16 +84,16 @@ extension APIRequestProtocol {
         #endif
     }
     var basePath: String {
-        return ""
+        ""
     }
     var urlString: String {
-        return scheme + host + basePath + path
+        scheme + host + basePath + path
     }
     var headers: [String: String] {
-        return [:]
+        [:]
     }
     var parameters: [String: Any] {
-        return [:]
+        [:]
     }
     var encodingType: ParameterEncodingType {
         switch method {
@@ -104,10 +104,10 @@ extension APIRequestProtocol {
         }
     }
     var acceptableStatusCode: Range<Int> {
-        return 200..<300
+        200..<300
     }
     var decoder: JSONDecoder? {
-        return nil
+        nil
     }
 }
 
@@ -127,6 +127,6 @@ extension APIRequestProtocol {
 
 extension APIRequestProtocol {
     var description: String {
-        return "[\(method.rawValue)] \(urlString)"
+        "[\(method.rawValue)] \(urlString)"
     }
 }

--- a/TraceCovid19/Sources/Screens/Home/HomeViewController.swift
+++ b/TraceCovid19/Sources/Screens/Home/HomeViewController.swift
@@ -74,7 +74,7 @@ final class HomeViewController: UIViewController, NVActivityIndicatorViewable, M
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
+        .lightContent
     }
 
     @IBAction func tappedMenuButton(_ sender: Any) {

--- a/TraceCovid19/Sources/Screens/Menu/Debug2ViewController.swift
+++ b/TraceCovid19/Sources/Screens/Menu/Debug2ViewController.swift
@@ -91,7 +91,7 @@ extension Debug2ViewController: UITableViewDelegate {
 
 extension Debug2ViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return positiveContact.positiveContacts.count
+        positiveContact.positiveContacts.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/TraceCovid19/Sources/Screens/Menu/Debug3ViewController.swift
+++ b/TraceCovid19/Sources/Screens/Menu/Debug3ViewController.swift
@@ -69,7 +69,7 @@ extension Debug3ViewController: UITableViewDelegate {
 
 extension Debug3ViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return tempUserIDs.count
+        tempUserIDs.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/TraceCovid19/Sources/Screens/Menu/DebugViewController.swift
+++ b/TraceCovid19/Sources/Screens/Menu/DebugViewController.swift
@@ -203,7 +203,7 @@ extension DebugViewController: UITableViewDelegate {
 
 extension DebugViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
+        2
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/TraceCovid19/Sources/Screens/Registrations/InputPrefectureViewController.swift
+++ b/TraceCovid19/Sources/Screens/Registrations/InputPrefectureViewController.swift
@@ -163,7 +163,7 @@ extension InputPrefectureViewController: UIPickerViewDataSource {
 // MARK: - UIPickerViewDelegate
 extension InputPrefectureViewController: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return PrefectureModel.rawValues[row]
+        PrefectureModel.rawValues[row]
     }
 
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {

--- a/TraceCovid19/Sources/Screens/Trace/TraceHistoryViewController.swift
+++ b/TraceCovid19/Sources/Screens/Trace/TraceHistoryViewController.swift
@@ -82,11 +82,11 @@ extension TraceHistoryViewController: NavigationBarHiddenApplicapable {
 
 extension TraceHistoryViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return sectionData.count
+        sectionData.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return sectionData[section].data.count
+        sectionData[section].data.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -97,7 +97,7 @@ extension TraceHistoryViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return TraceHistorySectionHeaderView.hight
+        TraceHistorySectionHeaderView.hight
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -154,6 +154,6 @@ final class TraceHistoryTableViewCell: UITableViewCell, NibInstantiatable {
 
 private extension DeepContactUser {
     var dateForHeader: String {
-        return startTime.toString(format: "yyyy年 M月 d日")
+        startTime.toString(format: "yyyy年 M月 d日")
     }
 }

--- a/TraceCovid19/Sources/Services/BLE/BLEService.swift
+++ b/TraceCovid19/Sources/Services/BLE/BLEService.swift
@@ -24,7 +24,7 @@ enum Service: CustomStringConvertible {
     }
 
     func toCBUUID() -> CBUUID {
-        return CBUUID(string: bleSSID)
+        CBUUID(string: bleSSID)
     }
 
     var description: String {
@@ -56,7 +56,7 @@ enum Characteristic: CustomStringConvertible {
     }
 
     func toCBUUID() -> CBUUID {
-        return CBUUID(string: type(of: self).characteristicId)
+        CBUUID(string: type(of: self).characteristicId)
     }
 
     var description: String {

--- a/TraceCovid19/Sources/Services/BLE/CentralManager.swift
+++ b/TraceCovid19/Sources/Services/BLE/CentralManager.swift
@@ -83,7 +83,7 @@ class CentralManager: NSObject {
     }
 
     func getState() -> CBManagerState {
-        return centralManager.state
+        centralManager.state
     }
 
     private func startScanning() {

--- a/TraceCovid19/Sources/Services/BLE/Peripheral.swift
+++ b/TraceCovid19/Sources/Services/BLE/Peripheral.swift
@@ -35,10 +35,10 @@ class Peripheral: NSObject {
     private var timer: Timer?
 
     var id: UUID {
-        return peripheral.identifier
+        peripheral.identifier
     }
     var shortId: String {
-        return peripheral.shortId
+        peripheral.shortId
     }
 
     init(peripheral: CBPeripheral, queue: DispatchQueue, services: [Service], commands: [Command], didUpdateValue: CharacteristicDidUpdateValue?, didReadRSSI: DidReadRSSI?) {

--- a/TraceCovid19/Sources/Services/BLE/PeripheralManager.swift
+++ b/TraceCovid19/Sources/Services/BLE/PeripheralManager.swift
@@ -53,7 +53,7 @@ class PeripheralManager: NSObject {
     }
 
     func getState() -> CBManagerState {
-        return peripheralManager.state
+        peripheralManager.state
     }
 
     private func startAdvertising() {

--- a/TraceCovid19/Sources/Services/BootService.swift
+++ b/TraceCovid19/Sources/Services/BootService.swift
@@ -21,7 +21,7 @@ final class BootService {
     private(set) var appStatus: AppStatusDetail?
 
     private var fileName: String {
-        return "app_status.json"
+        "app_status.json"
     }
 
     init(

--- a/TraceCovid19/Sources/Services/DeepContactCheckService.swift
+++ b/TraceCovid19/Sources/Services/DeepContactCheckService.swift
@@ -34,7 +34,7 @@ final class DeepContactCheckService {
     }
 
     func getDeepContactUsers() -> [DeepContactUser] {
-        return coreData.getDeepContactUsers().compactMap { $0.toDeepContactUser() }
+        coreData.getDeepContactUsers().compactMap { $0.toDeepContactUser() }
     }
 
     func getDeepContactUsersAtYesterday() -> [DeepContactUser] {

--- a/TraceCovid19/Sources/Services/LoginService.swift
+++ b/TraceCovid19/Sources/Services/LoginService.swift
@@ -90,11 +90,9 @@ final class LoginService {
     }
 
     private func requestLogin(profile: Profile, completion: @escaping (Result<Void, SignInError>) -> Void) {
-        loginAPI.login(profile: profile) { [weak self] result in
+        loginAPI.login(profile: profile) { result in
             switch result {
             case .success:
-                // 非同期で、とりあえず投げておく（結果は見ない）
-                self?.forceRefreshToken(profile: profile)
                 completion(.success(()))
             case .failure(.network):
                 completion(.failure(.network))
@@ -105,12 +103,6 @@ final class LoginService {
                 completion(.failure(.unknown(APIRequestError.authzError)))
             }
             print(result)
-        }
-    }
-
-    private func forceRefreshToken(profile: Profile) {
-        auth.instance.currentUser?.getIDTokenForcingRefresh(true) { token, error in
-            print("[LoginService] ForeceRefresh finished. token: \(token ?? "nil"), error: \(String(describing: error))")
         }
     }
 

--- a/TraceCovid19/Sources/Services/LoginService.swift
+++ b/TraceCovid19/Sources/Services/LoginService.swift
@@ -20,7 +20,7 @@ final class LoginService {
     private let profileService: ProfileService
 
     var isLogin: Bool {
-        return auth.instance.currentUser != nil
+        auth.instance.currentUser != nil
     }
 
     init(
@@ -132,11 +132,11 @@ final class LoginService {
 
     #if DEBUG
     var uid: String? {
-        return auth.instance.currentUser?.uid
+        auth.instance.currentUser?.uid
     }
 
     var phoneNumber: String? {
-        return auth.instance.currentUser?.phoneNumber
+        auth.instance.currentUser?.phoneNumber
     }
     #endif
 }

--- a/TraceCovid19/Sources/Services/PositiveContactService.swift
+++ b/TraceCovid19/Sources/Services/PositiveContactService.swift
@@ -21,7 +21,7 @@ final class PositiveContactService {
     private(set) var positiveContacts: [String] = []
 
     private var fileName: String {
-        return "positives.json.gz"
+        "positives.json.gz"
     }
 
     init(

--- a/TraceCovid19/Sources/Services/Storages/KeychainService+Property.swift
+++ b/TraceCovid19/Sources/Services/Storages/KeychainService+Property.swift
@@ -13,7 +13,7 @@ private extension String {
 
 extension KeychainService {
     var properties: [String] {
-        return [
+        [
             .uploadRamdomKeys
         ]
     }

--- a/TraceCovid19/Sources/Services/Storages/KeychainService.swift
+++ b/TraceCovid19/Sources/Services/Storages/KeychainService.swift
@@ -17,11 +17,11 @@ protocol KeychainClientProtocol {
 
 extension KeychainClientProtocol {
     func get(_ key: String) throws -> String? {
-        return try get(key, ignoringAttributeSynchronizable: true)
+        try get(key, ignoringAttributeSynchronizable: true)
     }
 
     func getData(_ key: String) throws -> Data? {
-        return try getData(key, ignoringAttributeSynchronizable: true)
+        try getData(key, ignoringAttributeSynchronizable: true)
     }
 
     func set(_ value: String, key: String) throws {

--- a/TraceCovid19/Sources/Services/TempIdService.swift
+++ b/TraceCovid19/Sources/Services/TempIdService.swift
@@ -36,15 +36,15 @@ final class TempIdService {
     }
 
     var tempIDs: [TempUserId] {
-        return coreData.getTempUserIDs()
+        coreData.getTempUserIDs()
     }
 
     var validTempIDs: [TempUserId] {
-        return filterIsValid(tempIDs: tempIDs)
+        filterIsValid(tempIDs: tempIDs)
     }
 
     var hasTempIDs: Bool {
-        return tempIDs.count != 0
+        tempIDs.count != 0
     }
 
     @discardableResult
@@ -64,7 +64,7 @@ final class TempIdService {
     }
 
     func getTempIdsForTwoWeeks() -> [TempUserId] {
-        return coreData.getTempUserIDsForTwoWeeks()
+        coreData.getTempUserIDsForTwoWeeks()
     }
 
     private func save(tempIds: [TempUserId]) {

--- a/TraceCovid19/Sources/Utilities/AssociatedObjects.swift
+++ b/TraceCovid19/Sources/Utilities/AssociatedObjects.swift
@@ -29,7 +29,7 @@ class AssociatedObjects: NSObject {
 
     subscript(key: String) -> Any? {
         get {
-            return dictionary[key]
+            dictionary[key]
         }
         set {
             dictionary[key] = newValue

--- a/TraceCovid19/Sources/Utilities/CBPeripheral+ShortId.swift
+++ b/TraceCovid19/Sources/Utilities/CBPeripheral+ShortId.swift
@@ -3,6 +3,6 @@ import CoreBluetooth
 
 extension CBPeripheral {
     var shortId: String {
-        return String(identifier.uuidString.prefix(8))
+        String(identifier.uuidString.prefix(8))
     }
 }

--- a/TraceCovid19/Sources/Utilities/CustomNavigationController.swift
+++ b/TraceCovid19/Sources/Utilities/CustomNavigationController.swift
@@ -14,7 +14,7 @@ final class CustomNavigationController: UINavigationController {
     }
 
     override var childForStatusBarStyle: UIViewController? {
-        return visibleViewController
+        visibleViewController
     }
 }
 
@@ -50,10 +50,10 @@ extension NavigationBarHiddenApplicapable {
     }
 
     var navigationBackgroundImage: UIImage? {
-        return UIImage()
+        UIImage()
     }
 
     var navigationShadowImage: UIImage {
-        return UIImage()
+        UIImage()
     }
 }

--- a/TraceCovid19/Sources/Utilities/DictionaryDecodable.swift
+++ b/TraceCovid19/Sources/Utilities/DictionaryDecodable.swift
@@ -16,11 +16,11 @@ protocol DictionaryDecodable: Decodable {
 
 extension DictionaryDecodable {
     static var jsonDecoder: JSONDecoder {
-        return JSONDecoder()
+        JSONDecoder()
     }
 
     static var ignoreDecodeKeys: [String] {
-        return []
+        []
     }
 }
 

--- a/TraceCovid19/Sources/Utilities/DictionaryEncodable.swift
+++ b/TraceCovid19/Sources/Utilities/DictionaryEncodable.swift
@@ -16,11 +16,11 @@ protocol DictionaryEncodable: Encodable {
 
 extension DictionaryEncodable {
     var jsonEncoder: JSONEncoder {
-        return JSONEncoder()
+        JSONEncoder()
     }
 
     static var ignoreEncodeKeys: [String] {
-        return []
+        []
     }
 }
 

--- a/TraceCovid19/Sources/Utilities/EncryptedStringTransformer.swift
+++ b/TraceCovid19/Sources/Utilities/EncryptedStringTransformer.swift
@@ -20,7 +20,7 @@ import RNCryptor
 @objc(EncryptedStringTransformer)
 final class EncryptedStringTransformer: ValueTransformer {
     private var p: String {
-        return "feawpjfa+JF213jifop" // TODO: フィールドの暗号化をちゃんとするなら共通鍵の管理を考える
+        "feawpjfa+JF213jifop" // TODO: フィールドの暗号化をちゃんとするなら共通鍵の管理を考える
     }
 
     override func transformedValue(_ value: Any?) -> Any? {

--- a/TraceCovid19/Sources/Utilities/KeyboardCloseProtocol.swift
+++ b/TraceCovid19/Sources/Utilities/KeyboardCloseProtocol.swift
@@ -30,6 +30,6 @@ extension KeyboardCloseProtocol {
 
 extension KeyboardCloseProtocol where Self: UIViewController {
     var target: UIView {
-        return view
+        view
     }
 }

--- a/TraceCovid19/Sources/Utilities/LabelUtilityProtocol.swift
+++ b/TraceCovid19/Sources/Utilities/LabelUtilityProtocol.swift
@@ -18,7 +18,7 @@ private let attributeKey = "_attributeKey"
 extension LabelUtilityProtocol where Self: UILabel {
     var attributes: [NSAttributedString.Key: Any] {
         get {
-            return associatedObjects[attributeKey] as? [NSAttributedString.Key: Any] ?? [:]
+            associatedObjects[attributeKey] as? [NSAttributedString.Key: Any] ?? [:]
         }
         set {
             associatedObjects[attributeKey] = newValue
@@ -34,7 +34,7 @@ extension LabelUtilityProtocol where Self: UILabel {
 
 extension LabelUtilityProtocol where Self: UILabel {
     var paragraphStyle: NSMutableParagraphStyle? {
-        return attributes[.paragraphStyle] as? NSMutableParagraphStyle
+        attributes[.paragraphStyle] as? NSMutableParagraphStyle
     }
 
     func setParagraph<T>(_ value: T, for keyPath: ReferenceWritableKeyPath<NSMutableParagraphStyle, T>) {

--- a/TraceCovid19/Sources/Utilities/NSObject+ClassName.swift
+++ b/TraceCovid19/Sources/Utilities/NSObject+ClassName.swift
@@ -9,10 +9,10 @@ import Foundation
 
 extension NSObject {
     class var className: String {
-        return String(describing: self)
+        String(describing: self)
     }
 
     var className: String {
-        return type(of: self).className
+        type(of: self).className
     }
 }

--- a/TraceCovid19/Sources/Utilities/SSLPinningManager.swift
+++ b/TraceCovid19/Sources/Utilities/SSLPinningManager.swift
@@ -70,7 +70,7 @@ final class SSLPinningManager {
     }
 
     var hosts: [String] {
-        return conditions.compactMap { $0.host }
+        conditions.compactMap { $0.host }
     }
 
     /// SSLチャレンジ処理を実行する
@@ -162,7 +162,7 @@ final class SSLPinningManager {
 
 private extension SSLPinningManager {
     var rsa2048Asn1Header: [UInt8] {
-        return [
+        [
             0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
             0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00
         ]

--- a/TraceCovid19/Sources/Utilities/UIGestureRecognizer+Closure.swift
+++ b/TraceCovid19/Sources/Utilities/UIGestureRecognizer+Closure.swift
@@ -29,7 +29,7 @@ private let key = "_closureWrapper"
 extension UITapGestureRecognizer: HasAssociatedObjects {
     private var closureWrapper: GestureClosureWrapper<UITapGestureRecognizer>? {
         get {
-            return associatedObjects[key] as? GestureClosureWrapper
+            associatedObjects[key] as? GestureClosureWrapper
         }
         set {
             associatedObjects[key] = newValue
@@ -53,7 +53,7 @@ extension UITapGestureRecognizer {
 extension UIPanGestureRecognizer: HasAssociatedObjects {
     private var closureWrapper: GestureClosureWrapper<UIPanGestureRecognizer>? {
         get {
-            return associatedObjects[key] as? GestureClosureWrapper
+            associatedObjects[key] as? GestureClosureWrapper
         }
         set {
             associatedObjects[key] = newValue

--- a/TraceCovid19/Sources/Utilities/UIView+NibInstantiable.swift
+++ b/TraceCovid19/Sources/Utilities/UIView+NibInstantiable.swift
@@ -16,16 +16,16 @@ protocol NibInstantiatable {
 }
 
 extension NibInstantiatable where Self: NSObject {
-    var nibName: String { return className }
-    var nibBundle: Bundle { return Bundle(for: type(of: self)) }
-    var nibOwner: Any? { return self }
-    var nibOptions: [UINib.OptionsKey: Any]? { return nil }
-    var instantiateIndex: Int { return 0 }
+    var nibName: String { className }
+    var nibBundle: Bundle { Bundle(for: type(of: self)) }
+    var nibOwner: Any? { self }
+    var nibOptions: [UINib.OptionsKey: Any]? { nil }
+    var instantiateIndex: Int { 0 }
 }
 
 extension NibInstantiatable where Self: UIView {
     func instantiate() -> UIView? {
-        return UINib(nibName: nibName, bundle: nibBundle).instantiate(withOwner: nibOwner, options: nibOptions)[instantiateIndex] as? UIView
+        UINib(nibName: nibName, bundle: nibBundle).instantiate(withOwner: nibOwner, options: nibOptions)[instantiateIndex] as? UIView
     }
 }
 

--- a/TraceCovid19/Sources/Utilities/UIViewController+Instantiate.swift
+++ b/TraceCovid19/Sources/Utilities/UIViewController+Instantiate.swift
@@ -14,25 +14,25 @@ import UIKit
 
 extension StoryboardInstantiatable where Self: NSObject {
     static var storyboardName: String {
-        return className
+        className
     }
 
     static var storyboardBundle: Bundle {
-        return Bundle(for: self)
+        Bundle(for: self)
     }
 
     private static var storyboard: UIStoryboard {
-        return UIStoryboard(name: storyboardName, bundle: storyboardBundle)
+        UIStoryboard(name: storyboardName, bundle: storyboardBundle)
     }
 }
 
 extension StoryboardInstantiatable where Self: UIViewController {
     static func instantiate() -> Self {
-        return storyboard.instantiateInitialViewController() as? Self ?? { fatalError("InitialViewControllerを変換できない") }()
+        storyboard.instantiateInitialViewController() as? Self ?? { fatalError("InitialViewControllerを変換できない") }()
     }
 
     static func instantiate(identifier: String) -> Self {
-        return storyboard.instantiateViewController(withIdentifier: identifier) as? Self ?? { fatalError("\(identifier)をViewControllerに変換できない") }()
+        storyboard.instantiateViewController(withIdentifier: identifier) as? Self ?? { fatalError("\(identifier)をViewControllerに変換できない") }()
     }
 }
 

--- a/TraceCovid19/Sources/Utilities/UIViewController+Utility.swift
+++ b/TraceCovid19/Sources/Utilities/UIViewController+Utility.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension UIViewController {
     var topBarHeight: CGFloat {
-        return UIApplication.shared.statusBarFrame.height +
+        UIApplication.shared.statusBarFrame.height +
             (navigationController?.navigationBar.bounds.height ?? 0.0)
     }
 }

--- a/TraceCovid19/Sources/Utilities/UUID+DataRepresentation.swift
+++ b/TraceCovid19/Sources/Utilities/UUID+DataRepresentation.swift
@@ -10,7 +10,7 @@ import CoreBluetooth
 
 extension UUID {
     var data: Data {
-        return withUnsafePointer(to: uuid) {
+        withUnsafePointer(to: uuid) {
             Data(bytes: $0, count: MemoryLayout.size(ofValue: uuid))
         }
     }

--- a/TraceCovid19/Sources/Utilities/XibLocalizable.swift
+++ b/TraceCovid19/Sources/Utilities/XibLocalizable.swift
@@ -24,11 +24,11 @@ extension XIBLocalizable {
 
 extension XIBLocalizable {
     var localizableFileName: String? {
-        return nil
+        nil
     }
 
     func localizedString(_ key: String) -> String {
-        return NSLocalizedString(key, tableName: localizableFileName, bundle: localizableBundle, comment: "")
+        NSLocalizedString(key, tableName: localizableFileName, bundle: localizableBundle, comment: "")
     }
 }
 

--- a/TraceCovid19/Sources/Views/BaseLabel.swift
+++ b/TraceCovid19/Sources/Views/BaseLabel.swift
@@ -18,7 +18,7 @@ class BaseLabel: UILabel, XIBLocalizable, LabelUtilityProtocol {
 
     @IBInspectable var spacing: CGFloat {
         get {
-            return paragraphStyle?.lineSpacing ?? 0.0
+            paragraphStyle?.lineSpacing ?? 0.0
         }
         set {
             setParagraph(newValue, for: \.lineSpacing)

--- a/TraceCovid19/Sources/Views/CodeInputUnitView.swift
+++ b/TraceCovid19/Sources/Views/CodeInputUnitView.swift
@@ -13,7 +13,7 @@ final class CodeInputUnitView: UIView, NibInstantiatable {
 
     var text: String {
         get {
-            return label.text ?? ""
+            label.text ?? ""
         }
         set {
             label.text = newValue

--- a/TraceCovid19/Sources/Views/CodeInputView.swift
+++ b/TraceCovid19/Sources/Views/CodeInputView.swift
@@ -22,7 +22,7 @@ final class CodeInputView: UIView {
 
     var text: String {
         get {
-            return textField.text ?? ""
+            textField.text ?? ""
         }
         set {
             textField.text = newValue
@@ -92,7 +92,7 @@ final class CodeInputView: UIView {
 
     @discardableResult
     override func becomeFirstResponder() -> Bool {
-        return textField.becomeFirstResponder()
+        textField.becomeFirstResponder()
     }
 }
 

--- a/TraceCovid19/Sources/Views/NoPerformActionTextField.swift
+++ b/TraceCovid19/Sources/Views/NoPerformActionTextField.swift
@@ -9,6 +9,6 @@ import UIKit
 
 class NoPerformActionTextField: BaseTextField {
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        return false
+        false
     }
 }


### PR DESCRIPTION
IDTokenのリフレッシュの管理はgetIDTokenメソッドを使うことでFirebase SDK側に移譲することができます。

ref: https://firebase.google.com/docs/reference/swift/firebaseauth/api/reference/Classes/User#/c:objc(cs)FIRUser(im)getIDTokenResultWithCompletion:

> Retrieves the Firebase authentication token, possibly refreshing it if it has expired.

APIコールの度にIDTokenのリフレッシュを行うのはパフォーマンスの低下につながるのでおすすめしません。

SwiftLintのautocorrectでreturnが省かれているものもコミットしておきますが、不要であれば取り除いてください。